### PR TITLE
fix: Cargo version constraint error by accepting partial updates

### DIFF
--- a/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
+++ b/cargo/spec/dependabot/cargo/file_updater/lockfile_updater_spec.rb
@@ -515,6 +515,98 @@ RSpec.describe Dependabot::Cargo::FileUpdater::LockfileUpdater do
           )
         end
       end
+
+      context "when cargo selects a different version due to dependency constraints" do
+        subject(:result) { updated_lockfile_content }
+
+        let(:previous_version) { Gem::Version.new(dependency_previous_version) }
+        let(:time_entry_regex) { /\[\[package\]\].*?name = "time".*?version = "(.*?)"/m }
+
+        context "when cargo selects a newer but different version" do
+          it "updates the dependency successfully" do
+            expect { result }.not_to raise_error
+
+            version_str = result.match(time_entry_regex)[1]
+            expect(Gem::Version.new(version_str)).to be > previous_version
+          end
+
+          # This test would fail without our implementation when cargo selects
+          # a different version than expected (e.g., 0.1.39 instead of 0.1.40)
+          context "when simulating version constraint scenario" do
+            let(:test_updater) do
+              described_class.new(
+                dependencies: [dependency],
+                dependency_files: dependency_files,
+                credentials: [{
+                  "type" => "git_source",
+                  "host" => "github.com"
+                }]
+              )
+            end
+
+            before do
+              # Mock the cargo update to return a different version
+              allow(test_updater).to receive(:run_cargo_command) do |command, _fingerprint|
+                if command.include?("cargo update")
+                  # Write a lockfile with 0.1.39 instead of expected 0.1.40
+                  constrained_lockfile = lockfile_body
+                                         .gsub("0.1.38", "0.1.39")
+                                         .gsub("d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520",
+                                               "a36d7c4b3b2b3bb5f51754f7b778dcbf88e99cd3")
+                  File.write("Cargo.lock", constrained_lockfile)
+                end
+              end
+            end
+
+            it "still accepts the update when version differs from expected" do
+              # This would raise "Failed to update time!" without our fix
+              result = test_updater.updated_lockfile_content
+              expect(result).to include('version = "0.1.39"')
+            end
+          end
+        end
+
+        describe ".LOCKFILE_ENTRY_REGEX" do
+          let(:sample) do
+            <<~LOCK
+              [[package]]
+              name = "time"
+              version = "0.1.39"
+              source = "registry+https://github.com/rust-lang/crates.io-index"
+              checksum = "abc123"
+            LOCK
+          end
+
+          it "matches a package stanza" do
+            expect(sample).to match(described_class::LOCKFILE_ENTRY_REGEX)
+          end
+
+          it "captures multiple package entries" do
+            double_sample = sample + "\n" + sample.gsub("time", "other").gsub("0.1.39", "1.0.0")
+            matches = double_sample.scan(described_class::LOCKFILE_ENTRY_REGEX)
+            expect(matches.size).to eq(2)
+          end
+        end
+
+        describe "version comparison behavior" do
+          it "correctly identifies newer versions" do
+            expect(Gem::Version.new("0.1.39")).to be > previous_version
+            expect(Gem::Version.new("0.1.40")).to be > previous_version
+            expect(Gem::Version.new("0.1.37")).not_to be > previous_version
+          end
+        end
+
+        context "when an impossible version is requested" do
+          let(:dependency_version) { "99.0.0" }
+          let(:requirements) do
+            [{ file: "Cargo.toml", requirement: "99.0.0", groups: [], source: nil }]
+          end
+
+          it "raises HelperSubprocessFailed" do
+            expect { result }.to raise_error(Dependabot::SharedHelpers::HelperSubprocessFailed)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes an issue where Dependabot fails to update Cargo dependencies when `cargo update` selects a different version than expected due to dependency constraints.

**Problem**: When updating dependencies like `actix-web` from 4.9.0 to 4.11.0, if complex dependency constraints cause Cargo to select version 4.10.2 instead of 4.11.0, Dependabot would fail with "Failed to update actix-web\!" error.

**Current User Experience in GitHub Actions**:
```
Dependabot encountered '2' error(s) during execution, please check the logs for more details.
+--------------------------------------------+
|       Dependencies failed to update        |
+------------+---------------+---------------+
| Dependency | Error Type    | Error Details |
+------------+---------------+---------------+
| actix-web  | unknown_error | null          |
| sea-orm    | unknown_error | null          |
+------------+---------------+---------------+
```

This generic `unknown_error` with `null` details makes debugging extremely difficult, as the actual RuntimeError ("Failed to update actix-web\!") is not surfaced to users.

**Root Cause**: 
1. In workspace configurations, VersionResolver uses a modified Cargo.toml with narrowed constraints (e.g., >= 4.9.0, <= 4.11.0)
2. LockfileUpdater uses the original Cargo.toml without these constraints
3. This discrepancy causes Cargo to potentially select different versions
4. The strict version check in LockfileUpdater fails when versions don't match exactly

### Why does cargo update stop at an intermediate version?

When running `cargo update -p actix-web` from version 4.9.0, Cargo updates to 4.10.2 and shows:
```
Updating actix-web v4.9.0 -> v4.10.2 (available: v4.11.0)
```

**Cargo's Conservative Update Strategy**:
- When using `-p <package>`, Cargo only updates the specified package with minimal dependency changes
- It does NOT automatically update dependencies that aren't strictly necessary
- It finds the highest compatible version requiring the fewest changes

**Example with actix-web**:
- actix-web 4.10.2 requires `actix-server ^2`, matching existing 2.5.0
- actix-web 4.11.0 requires `actix-server ^2.6`, needing an update from 2.5.0
- Since `-p actix-web` doesn't include actix-server, Cargo selects 4.10.2

This is by design to prevent unexpected breaking changes in your dependency tree.

### Anything you want to highlight for special attention from reviewers?

**⚠️ Known Limitation - Version Mismatch in PR Metadata**:

With this fix, there is a discrepancy between:
- **PR Title/Body**: Shows "⬆️ actix-web: 4.9.0 → 4.11.0" (from VersionResolver)
- **Actual Lockfile**: Contains version 4.10.2 (from Cargo's resolution)
- **updated_dependencies metadata**: Shows 4.11.0 as the target version

This happens because:
1. The `Dependency` objects are immutable once created
2. PR titles are generated from `dependency.version` which remains 4.11.0
3. Only the lockfile reflects the actual version (4.10.2) that Cargo selected

**Current Implementation**:
- Sets metadata (`actual_version`, `version_mismatch`) for future use
- These metadata fields are currently NOT used in PR title/body generation
- The discrepancy is only visible in logs: "Cargo selected version 4.10.2 instead of 4.11.0"

**Potential future improvements**:
1. Create new Dependency objects with corrected versions after lockfile update
2. Implement a post-processing step to update dependency versions based on lockfile
3. Modify PR title generation to check for and use `metadata[:actual_version]`

**Solution Approach**: 
- Modified `lockfile_updater.rb` to accept any version newer than the previous version when exact match fails
- Added `dependency_updated?` helper to check if version increased
- Added `extract_actual_version` helper to get the actual version Cargo selected
- Added informative logging when versions differ
- Set metadata for potential future use (not currently reflected in PR)

**Why this approach**:
1. Respects Cargo's expertise in dependency resolution
2. Maintains backward compatibility (tries exact match first)
3. Provides clear logging for debugging
4. Minimal change that solves the immediate problem
5. Trade-off: Accept PR metadata inaccuracy to enable successful updates

**Alternative approaches considered but rejected**:
1. Preventing constraint rewriting - Would require significant changes to how Dependabot determines updatable versions
2. Using same constraints in both components - Would require passing prepared files to LockfileUpdater, breaking current architecture
3. Updating Dependency objects - Would require significant architectural changes as dependencies are immutable

### How will you know you've accomplished your goal?

**Before this fix - GitHub Actions shows**:
```
| actix-web  | unknown_error | null          |
```
No useful debugging information is available to users.

**After this fix - Logs will show**:
```
Cargo selected version 4.10.2 instead of 4.11.0 for actix-web due to dependency constraints
```
The update proceeds successfully instead of failing with an opaque error.

**Test coverage**:
- Added TDD test simulating Cargo selecting 0.1.39 instead of 0.1.40
- Test fails without implementation (RuntimeError: Failed to update time\!)
- Test passes with implementation
- Unit tests for regex matching and version comparison
- Integration tests for version constraint scenarios

### Checklist

- [x] I have run the complete test suite to ensure all tests and linters pass.
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.

### Implementation Details

1. **Modified `lockfile_updater.rb`** (lines 46-59):
   ```ruby
   # If exact version match fails, accept any update
   if dependency_updated?(updated_lockfile, dependency)
     actual_version = extract_actual_version(updated_lockfile, dependency.name)
     if actual_version && actual_version \!= dependency.version
       Dependabot.logger.info(
         "Cargo selected version #{actual_version} instead of #{dependency.version} for #{dependency.name} " \
         "due to dependency constraints"
       )
       # Store in metadata for future use (not currently used in PR generation)
       dependency.metadata[:actual_version] = actual_version
       dependency.metadata[:version_mismatch] = true
       dependency.metadata[:expected_version] = dependency.version
     end
     next updated_lockfile
   end
   ```

2. **Fixed `LOCKFILE_ENTRY_REGEX`** (line 18) - **REQUIRED for the fix to work**:
   - Changed `(?\!^\[(\[package|metadata))` to `(?\!^\[(?:\[package|metadata))`
   - **Why this change is essential**:
     - Original regex with capture group returns `[[nil], [nil]]` from `scan`
     - This breaks `extract_actual_version` method which cannot process `[nil]` arrays
     - Without this fix, the method cannot extract version information from lockfile
     - **Without this regex fix, the entire version constraint solution fails**
   
   ```ruby
   # Before (broken):
   test.scan(regex) # => [[nil], [nil]]
   
   # After (working):
   test.scan(regex) # => ["[[package]]\nname = \"time\"\nversion = \"0.1.39\"\n...", ...]
   ```

3. **Added helper methods** (lines 429-465):
   - `dependency_updated?`: Checks if any version in lockfile is newer than previous
   - `extract_actual_version`: Gets the highest version from lockfile entries (depends on fixed regex)

### Impact

This change:
- **Improves debuggability**: Replaces opaque `unknown_error` with meaningful error messages
- **Fixes silent failures**: Updates succeed instead of failing when Cargo makes valid version choices
- **Addresses version mismatch errors** between VersionResolver and LockfileUpdater components
- **Provides better diagnostics** through clear logging of version selection decisions

**Known Trade-off**: PR metadata shows expected version (4.11.0) while actual update is to a different version (4.10.2). This discrepancy is accepted to enable successful updates rather than complete failure.

The solution respects Cargo's dependency resolution expertise while ensuring updates can proceed successfully and providing users with actionable information when issues occur.